### PR TITLE
Quiet option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,14 @@ Replace ```lat``` and ```lon``` with your location, and it will display all ADSB
 
 ### Advanced usage
 ```
-java -jar MavADSB.jar lat lon radius interval
+java -jar MavADSB.jar [-q] lat lon radius interval
 ```
 
 Replace ```radius``` with the polling radius around  ```lat,lon``` (up to 250) in nautical miles. Optional
 
 Replace ```interval``` with the polling interval in milliseconds (minimum 1000) in milliseconds. Optional
+
+Include ```-q``` (dash lower case letter Q) anywhere on the command line to suppress most messages. Optional
 
 ### Mission Planner integration
 After running the Jar file, please open Mission Planner and go to config tab -> Planner and look for the "Adsb" checkbox. Enable this and restart Mission Planner

--- a/src/main/kotlin/SBSServer.kt
+++ b/src/main/kotlin/SBSServer.kt
@@ -18,7 +18,7 @@ class SBSServer {
         }.start()
     }
 
-    fun sendData(data: ADSBData) {
+    fun sendData(data: ADSBData, quiet: Boolean) {
         Thread {
             val iterator = clients.iterator()
             while (iterator.hasNext()) {
@@ -34,7 +34,8 @@ class SBSServer {
                                 altitude = ac.getAltitude(),
                                 lat = ac.lat,
                                 lon = ac.lon,
-                                squawk = ac.squawk
+                                squawk = ac.squawk,
+                                quiet = quiet
                             )
                         )
                         writer.println(
@@ -44,7 +45,8 @@ class SBSServer {
                                 flightId = ac.getFlight(),
                                 groundSpeed = ac.gs,
                                 track = ac.track,
-                                squawk = ac.squawk
+                                squawk = ac.squawk,
+                                quiet = quiet
                             )
                         )
                         writer.flush()
@@ -74,7 +76,8 @@ class SBSServer {
         track: Double = 0.0,
         lat: Double = 0.0,
         lon: Double = 0.0,
-        squawk: String = ""
+        squawk: String = "",
+        quiet: Boolean = false
     ): String {
         val builder = StringBuilder()
         // The below basic data fields are standard for all messages (Field 2 used only for MSG)
@@ -103,7 +106,7 @@ class SBSServer {
         builder.append("0") // isOnGround
 
         val message = builder.toString()
-        println(message)
+        if (!quiet) println(message)
         return message
     }
 


### PR DESCRIPTION
Simple quiet option to suppress most messages.  

Could be generalized to extract an array of command line flags, rather than just the one.  

Might be worth refactoring at some point to separate the message generation (and console output) from the actual server function.  That would save having to pass the quiet flag to the server and avoid printing each message to the console for each client. 